### PR TITLE
mypy --strict: Use common type alias AsyncCallback for  all callbacks

### DIFF
--- a/asyncio_paho/__init__.py
+++ b/asyncio_paho/__init__.py
@@ -1,3 +1,5 @@
 """Asyncio Paho MQTT client module."""
 # flake8: noqa: F401
 from .client import AsyncioMqttAuthError, AsyncioMqttConnectError, AsyncioPahoClient
+
+__all__ = ["AsyncioMqttAuthError", "AsyncioMqttConnectError", "AsyncioPahoClient"]

--- a/asyncio_paho/client.py
+++ b/asyncio_paho/client.py
@@ -134,7 +134,7 @@ class AsyncioPahoClient(paho.Client):
         properties: paho.Properties | None = None,
     ) -> int:
         """Disconnect a connected client from the broker."""
-        result = super().disconnect(reasoncode, properties)
+        result: int = super().disconnect(reasoncode, properties)
         self._is_disconnecting = True
         if self._loop_misc_task:
             self._loop_misc_task.cancel()
@@ -154,7 +154,7 @@ class AsyncioPahoClient(paho.Client):
     ) -> None:
         # pylint: disable=too-many-arguments
         """Connect to a remote broker asynchronously and return when done."""
-        connect_future = self._event_loop.create_future()
+        connect_future: asyncio.Future[int] = self._event_loop.create_future()
         self._connect_callback_ex = None
         self._connect_callback_ex = None
 
@@ -215,7 +215,7 @@ class AsyncioPahoClient(paho.Client):
     ) -> int:
         # pylint: disable=too-many-arguments
         """Publish a message on a topic."""
-        subscribed_future = self._event_loop.create_future()
+        subscribed_future: asyncio.Future[int] = self._event_loop.create_future()
 
         result: paho.MQTTMessageInfo
 
@@ -389,6 +389,7 @@ class AsyncioPahoClient(paho.Client):
         # See reconnect_delay_set for details
         now = time.monotonic()
         with self._reconnect_delay_mutex:
+            self._reconnect_delay: int
             if self._reconnect_delay is None:
                 self._reconnect_delay = self._reconnect_min_delay
             else:

--- a/asyncio_paho/client.py
+++ b/asyncio_paho/client.py
@@ -296,7 +296,9 @@ class AsyncioPahoClient(paho.Client):
         self, client: paho.Client, _, sock: socket.socket
     ) -> None:
         self._event_loop.add_reader(sock, client.loop_read)
-        sock.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, 2048)
+        # When transport="websockets", sock is WebsocketWrapper which has no setsockopt:
+        if isinstance(sock, socket.socket):
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, 2048)
         self._ensure_loop_misc_started()
 
     def _on_socket_close_asyncio(

--- a/asyncio_paho/client.py
+++ b/asyncio_paho/client.py
@@ -420,12 +420,15 @@ class _EventType(Enum):
 
 class _Listeners:
     def __init__(
-        self, client: AsyncioPahoClient, loop: asyncio.AbstractEventLoop, log
+        self,
+        client: AsyncioPahoClient,
+        loop: asyncio.AbstractEventLoop,
+        log: Callable[[int, str, str], None],
     ) -> None:
         self._client = client
         self._event_loop = loop
         self._async_listeners: dict[_EventType, List[Any]] = {}
-        self._log: Callable = log
+        self._log = log
 
     def _handle_callback_result(self, task: asyncio.Task[None]) -> None:
         try:

--- a/asyncio_paho/client.py
+++ b/asyncio_paho/client.py
@@ -176,9 +176,9 @@ class AsyncioPahoClient(paho.Client):  # type: ignore
             # pylint: disable=unused-argument
             nonlocal connect_future
             if self._connect_callback_ex or self._connect_ex:
-                connect_future.set_exception(
-                    self._connect_ex if self._connect_ex else self._connect_callback_ex
-                )
+                connect_exception = self._connect_ex or self._connect_callback_ex
+                assert connect_exception
+                connect_future.set_exception(connect_exception)
             else:
                 result_code = args[3]
                 connect_future.set_result(result_code)

--- a/asyncio_paho/client.py
+++ b/asyncio_paho/client.py
@@ -27,7 +27,7 @@ def connect_result_code_to_exception(result_code: int) -> AsyncioMqttConnectErro
     return AsyncioMqttConnectError(result_code)
 
 
-class AsyncioMqttConnectError(MQTTException):
+class AsyncioMqttConnectError(MQTTException):  # type: ignore
     """MQTT connect error."""
 
     def __init__(self, result_code: int):
@@ -47,7 +47,7 @@ class AsyncioMqttAuthError(AsyncioMqttConnectError):
     """MQTT authentication error."""
 
 
-class AsyncioPahoClient(paho.Client):
+class AsyncioPahoClient(paho.Client):  # type: ignore
     # pylint: disable=too-many-instance-attributes
     """Paho MQTT Client using asyncio for connection loop."""
 

--- a/asyncio_paho/client.py
+++ b/asyncio_paho/client.py
@@ -6,7 +6,7 @@ import socket
 import time
 from collections.abc import Awaitable, Callable
 from enum import Enum, auto
-from typing import Any, List, Optional, Tuple, Union
+from typing import Any, Coroutine, Generator, List, Optional, Tuple, Union
 
 import paho.mqtt.client as paho
 from paho.mqtt import MQTTException
@@ -516,7 +516,10 @@ class _Listeners:
     def message_callback_add(
         self,
         sub: str,
-        callback: Callable[[paho.Client, Any, paho.MQTTMessage], Awaitable[None]],
+        callback: Callable[
+            [paho.Client, Any, paho.MQTTMessage],
+            Union[Coroutine[Any, Any, None], Generator[Any, None, None]],
+        ],
     ) -> None:
         """Register an async message callback for a specific topic."""
 

--- a/asyncio_paho/client.py
+++ b/asyncio_paho/client.py
@@ -459,7 +459,7 @@ class _Listeners:
 
         return unsubscribe
 
-    def _async_forwarder(self, event_type: _EventType, *args):
+    def _async_forwarder(self, event_type: _EventType, *args: Any) -> None:
         async_listeners = self._get_async_listeners(event_type)
         for listener in async_listeners:
             self._event_loop.create_task(
@@ -476,10 +476,10 @@ class _Listeners:
         is_high_pri: bool = False,
     ) -> Callable[[], None]:
         """Add on_connect async listener."""
-        paho.Client.on_connect.fset(self._client, self._on_connect_forwarder)  # type: ignore
+        paho.Client.on_connect.fset(self._client, self._on_connect_forwarder)
         return self._add_async_listener(_EventType.ON_CONNECT, callback, is_high_pri)
 
-    def _on_connect_forwarder(self, *args):
+    def _on_connect_forwarder(self, *args: Any) -> None:
         self._client._connect_callback_ex = None  # pylint: disable=protected-access
         try:
             self._async_forwarder(_EventType.ON_CONNECT, *args)
@@ -493,12 +493,12 @@ class _Listeners:
     ) -> Callable[[], None]:
         """Add on_connect_fail async listener."""
         on_connect_fail = paho.Client.on_connect_fail
-        on_connect_fail.fset(self._client, self._on_connect_fail_forwarder)  # type: ignore
+        on_connect_fail.fset(self._client, self._on_connect_fail_forwarder)
         return self._add_async_listener(
             _EventType.ON_CONNECT_FAILED, callback, is_high_pri
         )
 
-    def _on_connect_fail_forwarder(self, *args):
+    def _on_connect_fail_forwarder(self, *args: Any) -> None:
         self._async_forwarder(_EventType.ON_CONNECT_FAILED, *args)
 
     def add_on_message(
@@ -507,10 +507,10 @@ class _Listeners:
     ) -> Callable[[], None]:
         """Add on_connect_fail async listener."""
 
-        def forwarder(*args):
+        def forwarder(*args: Any) -> None:
             self._async_forwarder(_EventType.ON_MESSAGE, *args)
 
-        paho.Client.on_message.fset(self._client, forwarder)  # type: ignore
+        paho.Client.on_message.fset(self._client, forwarder)
         return self._add_async_listener(_EventType.ON_MESSAGE, callback)
 
     def message_callback_add(
@@ -520,7 +520,7 @@ class _Listeners:
     ) -> None:
         """Register an async message callback for a specific topic."""
 
-        def forwarder(*args):
+        def forwarder(*args: Any) -> None:
             self._event_loop.create_task(
                 callback(*args), name="message_callback"
             ).add_done_callback(self._handle_callback_result)
@@ -537,10 +537,10 @@ class _Listeners:
     ) -> Callable[[], None]:
         """Add on_subscribe async listener."""
 
-        def forwarder(*args):
+        def forwarder(*args: Any) -> None:
             self._async_forwarder(_EventType.ON_SUBSCRIBE, *args)
 
-        paho.Client.on_subscribe.fset(self._client, forwarder)  # type: ignore
+        paho.Client.on_subscribe.fset(self._client, forwarder)
         return self._add_async_listener(_EventType.ON_SUBSCRIBE, callback, is_high_pri)
 
     def add_on_publish(
@@ -550,8 +550,8 @@ class _Listeners:
     ) -> Callable[[], None]:
         """Add on_publish async listener."""
 
-        def forwarder(*args):
+        def forwarder(*args: Any) -> None:
             self._async_forwarder(_EventType.ON_PUBLISH, *args)
 
-        paho.Client.on_publish.fset(self._client, forwarder)  # type: ignore
+        paho.Client.on_publish.fset(self._client, forwarder)
         return self._add_async_listener(_EventType.ON_PUBLISH, callback, is_high_pri)

--- a/asyncio_paho/client.py
+++ b/asyncio_paho/client.py
@@ -90,7 +90,7 @@ class AsyncioPahoClient(paho.Client):
         """Enter contex."""
         return self
 
-    async def __aexit__(self, *args) -> None:
+    async def __aexit__(self, *args: Any, **kwargs: Any) -> None:
         """Exit context."""
         self.disconnect()
         if self._loop_misc_task:
@@ -274,7 +274,7 @@ class AsyncioPahoClient(paho.Client):
         self._userdata = userdata
         super().user_data_set(userdata)
 
-    def loop_forever(self, *args, **kvarg):
+    def loop_forever(self, *args: Any) -> None:
         """Invalid operation."""
         raise NotImplementedError(
             "loop_forever() cannot be used with AsyncioPahoClient."

--- a/asyncio_paho/client.py
+++ b/asyncio_paho/client.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 import asyncio
 import socket
 import time
-from collections.abc import Awaitable, Callable
+from collections.abc import Callable
 from enum import Enum, auto
 from typing import Any, Coroutine, Generator, List, Optional, Tuple, Union
 
-import paho.mqtt.client as paho
+import paho.mqtt.client as paho  # type: ignore
 from paho.mqtt import MQTTException
 
+AsyncCallback = Callable[[paho.Client, Any, int], Coroutine[Any, Any, None]]
 TopicList = List[Union[str, int]]
 CONNECTION_ERROR_CODES = {
     1: "Connection refused - incorrect protocol version",
@@ -449,7 +450,10 @@ class _Listeners:
         return self._async_listeners.setdefault(event_type, [])
 
     def _add_async_listener(
-        self, event_type: _EventType, callback, is_high_pri=False
+        self,
+        event_type: _EventType,
+        callback: AsyncCallback,
+        is_high_pri: bool = False,
     ) -> Callable[[], None]:
         listeners = self._get_async_listeners(event_type)
         if is_high_pri:
@@ -472,11 +476,7 @@ class _Listeners:
 
     def add_on_connect(
         self,
-        callback: Callable[[paho.Client, Any, dict[str, Any], int], Awaitable[None]]
-        | Callable[
-            [paho.Client, Any, dict[str, Any], paho.ReasonCodes, paho.Properties],
-            Awaitable[None],
-        ],
+        callback: AsyncCallback,
         is_high_pri: bool = False,
     ) -> Callable[[], None]:
         """Add on_connect async listener."""
@@ -492,7 +492,7 @@ class _Listeners:
 
     def add_on_connect_fail(
         self,
-        callback: Callable[[paho.Client, Any], Awaitable[None]],
+        callback: AsyncCallback,
         is_high_pri: bool = False,
     ) -> Callable[[], None]:
         """Add on_connect_fail async listener."""
@@ -507,7 +507,7 @@ class _Listeners:
 
     def add_on_message(
         self,
-        callback: Callable[[paho.Client, Any, paho.MQTTMessage], Awaitable[None]],
+        callback: AsyncCallback,
     ) -> Callable[[], None]:
         """Add on_connect_fail async listener."""
 
@@ -536,10 +536,7 @@ class _Listeners:
 
     def add_on_subscribe(
         self,
-        callback: Callable[[paho.Client, Any, int, tuple[int, ...]], Awaitable[None]]
-        | Callable[
-            [paho.Client, Any, int, list[int], paho.Properties], Awaitable[None]
-        ],
+        callback: AsyncCallback,
         is_high_pri: bool = False,
     ) -> Callable[[], None]:
         """Add on_subscribe async listener."""
@@ -552,7 +549,7 @@ class _Listeners:
 
     def add_on_publish(
         self,
-        callback: Callable[[paho.Client, Any, int], Awaitable[None]],
+        callback: AsyncCallback,
         is_high_pri: bool = False,
     ) -> Callable[[], None]:
         """Add on_publish async listener."""

--- a/asyncio_paho/client.py
+++ b/asyncio_paho/client.py
@@ -11,6 +11,7 @@ from typing import Any, Coroutine, Generator, List, Optional, Tuple, Union
 import paho.mqtt.client as paho
 from paho.mqtt import MQTTException
 
+TopicList = List[Union[str, int]]
 CONNECTION_ERROR_CODES = {
     1: "Connection refused - incorrect protocol version",
     2: "Connection refused - invalid client identifier",
@@ -239,7 +240,7 @@ class AsyncioPahoClient(paho.Client):  # type: ignore
 
     async def asyncio_subscribe(
         self,
-        topic: str | tuple | list,
+        topic: str | Tuple[Union[str, List[TopicList], Any] | TopicList],
         qos: int = 0,
         options: paho.SubscribeOptions | None = None,
         properties: paho.Properties | None = None,

--- a/asyncio_paho/client.py
+++ b/asyncio_paho/client.py
@@ -78,7 +78,7 @@ class AsyncioPahoClient(paho.Client):  # type: ignore
         self._is_connect_async = False
         self._connect_ex: Exception | None = None
         self._connect_callback_ex: Exception | None = None
-        self._loop_misc_task: asyncio.Task | None = None
+        self._loop_misc_task: asyncio.Task[None] | None = None
 
         self._asyncio_listeners = _Listeners(self, self._event_loop, self._log)
         self.on_socket_open = self._on_socket_open_asyncio
@@ -426,7 +426,7 @@ class _Listeners:
         self._async_listeners: dict[_EventType, List[Any]] = {}
         self._log: Callable = log
 
-    def _handle_callback_result(self, task: asyncio.Task) -> None:
+    def _handle_callback_result(self, task: asyncio.Task[None]) -> None:
         try:
             task.result()
             self._log(


### PR DESCRIPTION
mypy --strict: Use common type alias AsyncCallback for all callbacks

The callbacks are centrally routed thru one function and I'm not
sure if these callbacks have different call signatures. Do they?

Update: Yes indeed: https://github.com/toreamun/asyncio-paho#asyncio_listenersadd_on_connect

The rest is outdated, changed status to draft until the different callback signatures are added.

One of the callbacks is in asyncio_publish(), where on_publish
is added as a callback and it's function signature would have
to be supported.:
```py
async def on_publish(client: paho.Client, userdata: Any, mid: int) -> None:
    # pylint: disable=unused-argument
    nonlocal result
    if result.mid == mid:
        nonlocal subscribed_future
        subscribed_future.set_result(mid)

unsubscribe = self.asyncio_listeners.add_on_publish(
    on_publish, is_high_pri=True
)
```
This means the callback _add_async_listener which get on_publish() by
self.asyncio_listeners.add_on_publish() has to support it's signature.

This commit uses the signature of it and for the other add_on-callback
registrars. Not sure if this is correct, I guess there would need to
be tests using all these callbacks to know for sure.